### PR TITLE
Changed all to ff19SB for consistency; minor fixes

### DIFF
--- a/01-system_files/03-build_amber_system.py
+++ b/01-system_files/03-build_amber_system.py
@@ -3,7 +3,7 @@ from paprika.build.system import TLeap
 # Build AMBER Topologies for Ligand
 system = TLeap()
 system.output_path = "./"
-system.output_prefix = "ligand-ff14SB"
+system.output_prefix = "ligand-ff19SB"
 system.neutralize = False
 system.pbc_type = None
 system.template_lines = [
@@ -20,12 +20,12 @@ system.repartition_hydrogen_mass()
 # Build AMBER Topologies for Protein-Ligand system
 system = TLeap()
 system.output_path = "./"
-system.output_prefix = "protein-ligand-ff14SB"
+system.output_prefix = "protein-ligand-ff19SB"
 system.neutralize = False
 system.pbc_type = None
 system.template_lines = [
     "set default PBRadii mbondi2",
-    "source leaprc.protein.ff14SB",
+    "source leaprc.protein.ff19SB",
     #"source leaprc.water.opc",
     "source leaprc.gaff2",
     "loadamberparams ligand.frcmod",

--- a/03-alchemical/02-build_alchemical_workflow.py
+++ b/03-alchemical/02-build_alchemical_workflow.py
@@ -241,7 +241,7 @@ for window in tqdm(window_list):
     #print(f"Creating XML for window {window} ...")
 
     # Copy PDBFile
-    shutil.copy("../02-equilibration/extra_equilibrated.pdb", f"{folder}/system.pdb")
+    shutil.copy("../02-equilibration/production.pdb", f"{folder}/system.pdb")
 
     # Load OpenMM XML
     with open("../02-equilibration/protein_ligand.xml", "r") as file:
@@ -261,8 +261,8 @@ for window in tqdm(window_list):
 # ---------------------------- Create Elec-Bulk Files --------------------------------- #
 os.makedirs("electrostatics-bulk", exist_ok=True)
 
-prmtop = app.AmberPrmtopFile("../01-system_files/ligand-ff14SB.prmtop")
-inpcrd = app.AmberInpcrdFile("../01-system_files/ligand-ff14SB.rst7")
+prmtop = app.AmberPrmtopFile("../01-system_files/ligand-ff19SB.prmtop")
+inpcrd = app.AmberInpcrdFile("../01-system_files/ligand-ff19SB.rst7")
 system = prmtop.createSystem(
     nonbondedMethod=app.NoCutoff,
     constraints=app.HBonds,
@@ -300,7 +300,7 @@ for i, lb in enumerate(tqdm(lambda_elec_values)):
     window = f"e{i:03}"
     os.makedirs(f"electrostatics-site/{window}", exist_ok=True)
     shutil.copy(
-        "../02-equilibration/extra_equilibrated.pdb",
+        "../02-equilibration/production.pdb",
         f"electrostatics-site/{window}/system.pdb",
     )
     with open(f"electrostatics-site/{window}/system.xml", "w") as file:
@@ -325,7 +325,7 @@ for i, lb in enumerate(tqdm(lambda_vdw_values)):
     window = f"v{i:03}"
     os.makedirs(f"lennard-jones/{window}", exist_ok=True)
     shutil.copy(
-        "../02-equilibration/extra_equilibrated.pdb",
+        "../02-equilibration/production.pdb",
         f"lennard-jones/{window}/system.pdb",
     )
     with open(f"lennard-jones/{window}/system.xml", "w") as file:

--- a/03-alchemical/README.md
+++ b/03-alchemical/README.md
@@ -8,4 +8,6 @@ Here, we will generate the files for running the double-decoupling method (DDM).
 The last part is estimated analytically so no simulation will be needed. I've configured the scripts to make signs  match so that the binding free energy is just the sum of all the components: 
 
 
-DG_b = DG(attach) + DG(elec_site) + DG(vdw) + DG(elec_bulk) + DG(release)
+$\Delta G_{binding} = \Delta G_{attach} + \Delta G_{elec\_site} + \Delta G_{VDW} + \Delta G_{elec\_bulk} + \Delta G_{release}$
+
+The experimental $\Delta G_{binding} = -11.22\;\mathrm{kcal/mol}$.

--- a/03-alchemical/README.md
+++ b/03-alchemical/README.md
@@ -8,6 +8,6 @@ Here, we will generate the files for running the double-decoupling method (DDM).
 The last part is estimated analytically so no simulation will be needed. I've configured the scripts to make signs  match so that the binding free energy is just the sum of all the components: 
 
 
-$\Delta G_{binding} = \Delta G_{attach} + \Delta G_{elec\_site} + \Delta G_{VDW} + \Delta G_{elec\_bulk} + \Delta G_{release}$
+$\Delta G_{binding} = \Delta G_{attach} + \Delta G_{elec}^{site} + \Delta G_{VDW} + \Delta G_{elec}^{bulk} + \Delta G_{release}$
 
 The experimental $\Delta G_{binding} = -11.22\;\mathrm{kcal/mol}$.

--- a/03-alchemical/simulation-scripts/simulate_electrostatics-bulk.py
+++ b/03-alchemical/simulation-scripts/simulate_electrostatics-bulk.py
@@ -134,7 +134,10 @@ def run_molecular_dynamics_alchemical(
 
     # MD Step
     simulation.step(time_steps["simulation_steps"][phase])
-    simulation.saveState(f"{phase}-{window_number}.xml")
+    if phase == "production":
+        simulation.saveState(f"{phase}-{window_number}.xml")
+    else:
+        simulation.saveState(f"{phase}.xml")
     logger.info(f"\t\tCompleted running {phase} phase ...")
 
 
@@ -245,7 +248,7 @@ run_molecular_dynamics_alchemical(
     minimize_energy=True,
     write_energy=True,
     write_trajectory=False,
-    write_checkpoint=False,
+    write_checkpoint=True,
     properties=platform_properties,
 )
 


### PR DESCRIPTION
A few minor fixes for running smoothly out of the box.

Not added in this PR but could the expt value for the sample system be written in either `01-system_files/README.md` or somewhere in `03-alchemical/analysis-script`? ~~Using an expt $K_d$ of 0.670 $\mathrm{\mu M}$ I got $-8.42$ kcal/mol, please let me know if this is right though.~~ Used wrong $K_d$, it should be $K_d=0.006\mathrm{\mu M}$ which gives $-11.22$ kcal/mol.